### PR TITLE
fix: Avoid loss of custom value after editing

### DIFF
--- a/ui/components/UIScheduler.vue
+++ b/ui/components/UIScheduler.vue
@@ -2126,15 +2126,15 @@ export default {
                     newSchedule.payloadValue = true
                     newSchedule.endPayloadValue = false
                 } else {
-                    newSchedule.payloadValue = this.customPayloadStart
-                    newSchedule.endPayloadValue = this.customPayloadEnd
+                    newSchedule.payloadValue = (this.customPayloadStart?.id) ? this.customPayloadStart.id : this.customPayloadStart
+                    newSchedule.endPayloadValue = (this.customPayloadEnd?.id) ? this.customPayloadEnd.id : this.customPayloadEnd
                 }
             } else {
                 newSchedule.payloadType = this.payloadType
                 if (this.payloadType !== 'custom' && this.payloadType !== 'true_false') {
                     newSchedule.payloadValue = this.payloadType
                 } else if (this.payloadType === 'custom') {
-                    newSchedule.payloadValue = this.customPayloadStart
+                    newSchedule.payloadValue = (this.customPayloadStart?.id) ? this.customPayloadStart.id : this.customPayloadStart
                 }
             }
 


### PR DESCRIPTION
Fix: when editing a schedule with a custom output value without making any changes, the value is lost when saving.